### PR TITLE
Remove unnecessary files from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,12 @@
     "**/.*",
     "node_modules",
     "bower_components",
-    "test",
-    "tests"
+    "htdocs",
+    "spec",
+    "src",
+    "package.json",
+    "component.json",
+    "Gruntfile.*"
   ],
   "dependencies": {
     "d3": "~3.4.4"


### PR DESCRIPTION
Currently `c3` bower component includes lots of unnecessary stuff like src, spec, examples and unrelated config files. This PR removes them.