### PR TITLE
Adds c3_chart_internal_fn.isTabVisible to disable transitions on inactive tabs. Fixes #924.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -611,7 +611,7 @@ c3_chart_internal_fn.redraw = function (options, transitions) {
         });
     }
 
-    if (duration) {
+    if (duration && $$.isTabVisible()) { // Only use transition if tab visible. See #938.
         // transition should be derived from one transition
         d3.transition().duration(duration).each(function () {
             var transitionsToWait = [];
@@ -947,4 +947,19 @@ c3_chart_internal_fn.parseDate = function (date) {
         window.console.error("Failed to parse x '" + date + "' to Date object");
     }
     return parsedDate;
+};
+
+c3_chart_internal_fn.isTabVisible = function () {
+    var hidden;
+    if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
+        hidden = "hidden";
+    } else if (typeof document.mozHidden !== "undefined") {
+        hidden = "mozHidden";
+    } else if (typeof document.msHidden !== "undefined") {
+        hidden = "msHidden";
+    } else if (typeof document.webkitHidden !== "undefined") {
+        hidden = "webkitHidden";
+    }
+
+    return document[hidden] ? false : true;
 };


### PR DESCRIPTION
This adds a new function, `c3_chart_internal_fn.isTabVisible`, which uses the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/Guide/User_experience/Using_the_Page_Visibility_API) to return whether the page is inactive or not. I've then called it `c3_chart_internal_fn.redraw()` on line 614 of `src/core.js`, which short-circuits the conditional and renders the chart without using `d3.transition` (which uses the `requestAnimationFrame` API, which doesn't work on inactive tabs) if the chart's browser tab is inactive.

See #924.