### PR TITLE
Correct input for generateGetAreaPoints

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -62,7 +62,7 @@ c3_chart_internal_fn.getTextRect = function (text, cls) {
 };
 c3_chart_internal_fn.generateXYForText = function (areaIndices, barIndices, lineIndices, forX) {
     var $$ = this,
-        getAreaPoints = $$.generateGetAreaPoints(barIndices, false),
+        getAreaPoints = $$.generateGetAreaPoints(areaIndices, false),
         getBarPoints = $$.generateGetBarPoints(barIndices, false),
         getLinePoints = $$.generateGetLinePoints(lineIndices, false),
         getter = forX ? $$.getXForText : $$.getYForText;


### PR DESCRIPTION
Fixes an issue where generateGetAreaPoints was taking in the wrong input
causing labels for area charts to be incorrectly positioned. Fixes #980.