### PR TITLE
GH-1007 typo causes isCategorized to fail

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -717,7 +717,7 @@
         return this.config.axis_x_type === 'timeseries';
     };
     c3_chart_internal_fn.isCategorized = function () {
-        return this.config.axis_x_type.indexOf('categor') >= 0;
+        return this.config.axis_x_type.indexOf('category') >= 0;
     };
     c3_chart_internal_fn.isCustomX = function () {
         var $$ = this, config = $$.config;


### PR DESCRIPTION
'categor' should be 'category'

Fixes #1007

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>