### PR TITLE
Fix Function.prototype.bind polyfill by using Mozillas suggested script

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,7 +1,25 @@
-// fix problems using c3 with phantomjs #578
-Function.prototype.bind = Function.prototype.bind || function (thisp) {
-    var fn = this;
-    return function () {
-        return fn.apply(thisp, arguments);
-    };
-};
+// PhantomJS doesn't have support for Function.prototype.bind, which has caused confusion. Use
+// this polyfill to avoid the confusion.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill
+
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP ? this : oThis, aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}


### PR DESCRIPTION
### Problem

This PR fixes a bug with the `Function.prototype.bind` polyfill where arguments passed into `bind` weren't being included when the function was eventually executed. I've included three examples showing the expectation without a polyfill, what's currently happening in master, and how the polyfill should be implemented in order to emulate the baseline.

[No Polyfill (baseline)](http://jsbin.com/jugelaheji/1/edit?js,console)
[C3 master (broken)](http://jsbin.com/sixoqeduco/1/edit?js,console)

### Solution

[C3 matthelm:phantom-polyfill (fixed)](http://jsbin.com/qunesepive/1/edit?js,console)

The code for the PR is copied from MDN's suggested polyfill [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill). I'm unsure how to best write tests for this code, and because the current polyfill didn't have tests I'm submitting this PR without any. That said, I'm happy to add them.