### PR TITLE
Fix for issue #1054

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -983,7 +983,7 @@ c3_chart_internal_fn.parseDate = function (date) {
         parsedDate = date;
     } else if (typeof date === 'string') {
         parsedDate = $$.dataTimeFormat($$.config.data_xFormat).parse(date);
-    } else if (typeof date === 'number' || !isNaN(date)) {
+    } else if (typeof date === 'number' && !isNaN(date)) {
         parsedDate = new Date(+date);
     }
     if (!parsedDate || isNaN(+parsedDate)) {


### PR DESCRIPTION
This is the fix for the issue "Problem parsing date on parseDate function when date is a string".
The validation when 'date' is a number was wrong.