### PR TITLE
Allow patch upgrades to D3.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "gitHead": "84e03109d9a590f9c8ef687c03d751f666080c6f",
   "readmeFilename": "README.md",
   "dependencies": {
-    "d3": "<=3.5.0"
+    "d3": "~3.5.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
We ran into a problem with D3.js that was resolved in a later patch version (v3.5.4).  This small change allows patch upgrades to D3.js (3.5.x) while locking the minor version (i.e., it won't upgrade to 3.6.x).