### PR TITLE
Add the ability to prevent elements from the showing up in legend and tool-tip

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -53,7 +53,7 @@ c3_chart_internal_fn.addName = function (data) {
     var $$ = this, name;
     if (data) {
         name = $$.config.data_names[data.id];
-        data.name = name ? name : data.id;
+        data.name = name !== undefined ? name : data.id;
     }
     return data;
 };

--- a/src/legend.js
+++ b/src/legend.js
@@ -119,6 +119,9 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
     var withTransition, withTransitionForTransform;
     var texts, rects, tiles, background;
 
+    // Skip elements when their name is set to null
+    targetIds = targetIds.filter(function(id) {return !isDefined(config.data_names[id]) || config.data_names[id] !== null;});
+
     options = options || {};
     withTransition = getOption(options, "withTransition", true);
     withTransitionForTransform = getOption(options, "withTransitionForTransform", true);

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -40,6 +40,8 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
 
         value = valueFormat(d[i].value, d[i].ratio, d[i].id, d[i].index);
         if (value !== undefined) {
+            // Skip elements when their name is set to null
+            if (d[i].name === null) { continue; }
             name = nameFormat(d[i].name, d[i].ratio, d[i].id, d[i].index);
             bgcolor = $$.levelColor ? $$.levelColor(d[i].value) : color(d[i].id);
 


### PR DESCRIPTION
As the title suggests, we're trying to prevent specific series from showing up in the legend and too-tips.

This patch allows series to be hidden from these when their names are set null via the data_names option.

I'll be happy to update the patch if there's an alternative approach that's preferred.