### PR TITLE
Switch selectAll syntax from array syntax to comma separated.  #1189

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -856,7 +856,7 @@ c3_chart_internal_fn.updateSvgSize = function () {
     var $$ = this,
         brush = $$.svg.select(".c3-brush .background");
     $$.svg.attr('width', $$.currentWidth).attr('height', $$.currentHeight);
-    $$.svg.selectAll(['#' + $$.clipId, '#' + $$.clipIdForGrid]).select('rect')
+    $$.svg.selectAll(['#' + $$.clipIdForGrid,'#' + $$.clipId].join(',')).select('rect')
         .attr('width', $$.width)
         .attr('height', $$.height);
     $$.svg.select('#' + $$.clipIdForXAxis).select('rect')


### PR DESCRIPTION
Our code matches the donut sample pretty much verbatim, but we get nothing displayed without the change in the pull request. 

http://c3js.org/samples/chart_donut.html

Test code that needs a little bit of cleanup.  It feels like it's testing a side effect.  Can clean it up if you've got any suggestions.

```
        it('Clip paths should have a width', function() {

            var defs = d3.select('#chart svg').select('defs');

            //can't select clip path via d3 select (at least in phantom)
            var clips = [].reduce.call(defs.node().childNodes, function(memo, child) {
                expect(d3.select(child).select('rect').attr('width')).toBeDefined();
                memo.push(child);
                return memo;
            }, []);

            clips = d3.selectAll(clips);

            clips.selectAll('rect').attr('width', null);

            clips.each(function() {
                expect(d3.select(this).select('rect').attr('width')).toBeNull();
            });

            chart.internal.updateSvgSize();

            clips.each(function() {
                expect(d3.select(this).select('rect').attr('width')).toBeDefined()
            });

            expect(clips.size()).toBe(5);
        });

```