### PR TITLE
Change legend method customization to be consistent across all methods

### DIFF
--- a/src/legend.js
+++ b/src/legend.js
@@ -240,19 +240,23 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
             }
         })
         .on('mouseover', function (id) {
-            $$.d3.select(this).classed(CLASS.legendItemFocused, true);
-            if (!$$.transiting && $$.isTargetToShow(id)) {
-                $$.api.focus(id);
-            }
             if (config.legend_item_onmouseover) {
                 config.legend_item_onmouseover.call($$, id);
             }
+            else {
+                $$.d3.select(this).classed(CLASS.legendItemFocused, true);
+                if (!$$.transiting && $$.isTargetToShow(id)) {
+                    $$.api.focus(id);
+                }
+            }
         })
         .on('mouseout', function (id) {
-            $$.d3.select(this).classed(CLASS.legendItemFocused, false);
-            $$.api.revert();
             if (config.legend_item_onmouseout) {
                 config.legend_item_onmouseout.call($$, id);
+            }
+            else {
+                $$.d3.select(this).classed(CLASS.legendItemFocused, false);
+                $$.api.revert();    
             }
         });
     l.append('text')


### PR DESCRIPTION
Ref #1208 

Alter how custom methods work in the `mouseover`/`mouseout` legend events to be consistent with how `click` works.