### PR TITLE
accepts numeric input in mapToTargetIds

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -1780,7 +1780,7 @@
     };
     c3_chart_internal_fn.mapToTargetIds = function (ids) {
         var $$ = this;
-        return ids ? (isString(ids) ? [ids] : ids) : $$.mapToIds($$.data.targets);
+        return ids ? (isString(ids) || isNumber(ids) ? [ids] : ids) : $$.mapToIds($$.data.targets);
     };
     c3_chart_internal_fn.hasTarget = function (targets, id) {
         var ids = this.mapToIds(targets), i;
@@ -5935,6 +5935,9 @@
         },
         isString = c3_chart_internal_fn.isString = function (o) {
             return typeof o === 'string';
+        },
+        isNumber = c3_chart_internal_fn.isNumber = function (o) {
+            return typeof o === 'number';
         },
         isUndefined = c3_chart_internal_fn.isUndefined = function (v) {
             return typeof v === 'undefined';


### PR DESCRIPTION
I noticed that the method *removeHiddenTargetIds* was throwing an error when when showing a formerly hidden label in a donut chart. It turns out the error happened because the `targetIds` argument was a number instead of an array.

I traced the error back to

```js
    c3_chart_internal_fn.mapToTargetIds = function (ids) {
        var $$ = this;
        return ids ? (isString(ids) ? [ids] : ids) : $$.mapToIds($$.data.targets);
    };
```

See, when `ids` is a string, it's correctly transformed to an array, whereas if ids is a number, it will still be a number. In this pull request I added the function isNumber

```
    isNumber = c3_chart_internal_fn.isNumber = function (o) {
        return typeof o === 'number';
    },
```

and checked for number type at `mapToTargetIds`

```js
    c3_chart_internal_fn.mapToTargetIds = function (ids) {
        var $$ = this;
        return ids ? (isString(ids) || isNumber(ids) ? [ids] : ids) : $$.mapToIds($$.data.targets);
    };
```

so numeric ids are transformed to arrays as expected.