### PR TITLE
Fix firefox NS_ERROR_FAILURE issue caused by the new titles feature

### DIFF
--- a/src/title.js
+++ b/src/title.js
@@ -13,9 +13,9 @@ c3_chart_internal_fn.redrawTitle = function () {
 c3_chart_internal_fn.xForTitle = function () {
     var $$ = this, config = $$.config, position = config.title_position || 'left', x;
     if (position.indexOf('right') >= 0) {
-        x = $$.currentWidth - $$.title.node().getBBox().width - config.title_padding.right;
+        x = $$.currentWidth - $$.title.node().getBoundingClientRect().width - config.title_padding.right;
     } else if (position.indexOf('center') >= 0) {
-        x = ($$.currentWidth - $$.title.node().getBBox().width) / 2;
+        x = ($$.currentWidth - $$.title.node().getBoundingClientRect().width) / 2;
     } else { // left
         x = config.title_padding.left;
     }
@@ -23,7 +23,7 @@ c3_chart_internal_fn.xForTitle = function () {
 };
 c3_chart_internal_fn.yForTitle = function () {
     var $$ = this;
-    return $$.config.title_padding.top + $$.title.node().getBBox().height;
+    return $$.config.title_padding.top + $$.title.node().getBoundingClientRect().height;
 };
 c3_chart_internal_fn.getTitlePadding = function() {
     var $$ = this;


### PR DESCRIPTION
NS_ERROR_FAILURE when rendering titles in off-screen chart in firefox only. This is a reintroduction of same issue in #131. Applied same fix as cd004fea.