### PR TITLE
Fix #1229 - Incorrect x tick positioning

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -171,7 +171,8 @@ c3_chart_internal_fn.filterTargetsToShow = function (targets) {
 c3_chart_internal_fn.mapTargetsToUniqueXs = function (targets) {
     var $$ = this;
     var xs = $$.d3.set($$.d3.merge(targets.map(function (t) { return t.values.map(function (v) { return +v.x; }); }))).values();
-    return $$.isTimeSeries() ? xs.map(function (x) { return new Date(+x); }) : xs.map(function (x) { return +x; });
+    xs = $$.isTimeSeries() ? xs.map(function (x) { return new Date(+x); }) : xs.map(function (x) { return +x; });
+    return xs.sort(function (a, b) { return a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN; });
 };
 c3_chart_internal_fn.addHiddenTargetIds = function (targetIds) {
     this.hiddenTargetIds = this.hiddenTargetIds.concat(targetIds);


### PR DESCRIPTION
Fix #1229 - Incorrect x tick positioning

``Axis.prototype.generateTickValues`` incorrectly assumes that the input ``values`` (unique x values) will be numerically/date sorted. These values are extracted by ``c3_chart_internal_fn.mapTargetsToUniqueXs`` which uses ``d3.set.values``. The order of the output of ``d3.set.values`` is [not guaranteed](https://github.com/mbostock/d3/wiki/Arrays#set_values) (it happens to be string alpha sorted). In many cases this does not matter, but if the min or max numeric value get put in the wrong position the erroneous behavior is seen.

I have simply added a guard in ``c3_chart_internal_fn.mapTargetsToUniqueXs``, to numerically sort the unique x values before passing into ``Axis.prototype.generateTickValues``.

Before: http://codepen.io/anon/pen/xGPVgJ?editors=001
After: http://codepen.io/anon/pen/jPaqGB?editors=001