### PR TITLE
Makes subchart x-axis visibility dependent upon subchart visibility

### DIFF
--- a/src/subchart.js
+++ b/src/subchart.js
@@ -40,7 +40,7 @@ c3_chart_internal_fn.initSubchart = function () {
         .attr("class", CLASS.axisX)
         .attr("transform", $$.getTranslate('subx'))
         .attr("clip-path", config.axis_rotated ? "" : $$.clipPathForXAxis)
-        .style("visibility", config.subchart_axis_x_show ? 'visible' : 'hidden');
+        .style("visibility", config.subchart_show && config.subchart_axis_x_show ? 'visible' : 'hidden');
 };
 c3_chart_internal_fn.updateTargetsForSubchart = function (targets) {
     var $$ = this, context = $$.context, config = $$.config,


### PR DESCRIPTION
Currently it's [possible to see the subchart x-axis](http://jsfiddle.net/aendrew/Lr6dbgwb/5/) if `subchart.visible` is `false` but `subchart.axis.x.visible` is `true` (and the SVG area gets extended a bit). See #1246.

This PR short-circuits the conditional for `subchart.axis.x.visible` if `subchart.visible` is falsy. 