### PR TITLE
Allow data series with unequal amount of x-values

### DIFF
--- a/src/shape.js
+++ b/src/shape.js
@@ -41,8 +41,23 @@ c3_chart_internal_fn.getShapeOffset = function (typeFilter, indices, isSub) {
             var values = $$.isStepType(d) ? $$.convertValuesToStep(t.values) : t.values;
             if (t.id === d.id || indices[t.id] !== indices[d.id]) { return; }
             if (targetIds.indexOf(t.id) < targetIds.indexOf(d.id)) {
-                if (values[i].value * d.value >= 0) {
-                    offset += scale(values[i].value) - y0;
+                // check if the x values line up
+                if (typeof values[i] === 'undefined' ||
+                    (values[i].x !== d.x) && (values[i].x - d.x !== 0)) {
+                    // if not, try to find the value that does line up
+                    i = -1;
+                    for (var j in values) {
+                        if ((values[j].x === d.x) || (values[j].x - d.x === 0)) {
+                            i = j;
+                            break;
+                        }
+                    }
+                }
+
+                if (i in values) {
+                    if (values[i].value * d.value >= 0) {
+                        offset += scale(values[i].value) - y0;
+                    }
                 }
             }
         });


### PR DESCRIPTION
This is in reference to issue #1065 and proposing a pull request for the fix by @craigsoules . Currently, if there are data series that have an unequal amount of x-values, then there is a possibility that the code will error by trying to access an index out of bounds. This fix allows uneven data sets. 