### PR TITLE
Fixing firefox issue (mozilla bugzilla: #612118) for title rendering.

### DIFF
--- a/src/title.js
+++ b/src/title.js
@@ -11,19 +11,39 @@ c3_chart_internal_fn.redrawTitle = function () {
           .attr("y", $$.yForTitle.bind($$));
 };
 c3_chart_internal_fn.xForTitle = function () {
-    var $$ = this, config = $$.config, position = config.title_position || 'left', x;
+    var $$ = this, config = $$.config, position = config.title_position || 'left', x, textWidth;
+    try {
+			textWidth = $$.title.node().getBBox().width;
+		} catch (e) {
+			//FF bug https://bugzilla.mozilla.org/show_bug.cgi?id=612118
+			if (e.name === 'NS_ERROR_FAILURE') {
+				textWidth = $$.title.node().getComputedTextLength();
+			} else {
+				throw(e);
+      }
+		}
     if (position.indexOf('right') >= 0) {
-        x = $$.currentWidth - $$.title.node().getBBox().width - config.title_padding.right;
+        x = $$.currentWidth - textWidth - config.title_padding.right;
     } else if (position.indexOf('center') >= 0) {
-        x = ($$.currentWidth - $$.title.node().getBBox().width) / 2;
+        x = ($$.currentWidth - textWidth) / 2;
     } else { // left
         x = config.title_padding.left;
     }
     return x;
 };
 c3_chart_internal_fn.yForTitle = function () {
-    var $$ = this;
-    return $$.config.title_padding.top + $$.title.node().getBBox().height;
+    var $$ = this, textHeight;
+    try {
+			textHeight = $$.title.node().getBBox().height;
+		} catch (e) {
+			//FF bug https://bugzilla.mozilla.org/show_bug.cgi?id=612118
+			if (e.name === 'NS_ERROR_FAILURE') {
+				textHeight = 0;
+			} else {
+				throw(e);
+			}
+		}
+    return $$.config.title_padding.top + textHeight;
 };
 c3_chart_internal_fn.getTitlePadding = function() {
     var $$ = this;

--- a/src/title.js
+++ b/src/title.js
@@ -21,7 +21,7 @@ c3_chart_internal_fn.xForTitle = function () {
 			} else {
 				throw(e);
       }
-		}
+    }
     if (position.indexOf('right') >= 0) {
         x = $$.currentWidth - textWidth - config.title_padding.right;
     } else if (position.indexOf('center') >= 0) {
@@ -41,8 +41,8 @@ c3_chart_internal_fn.yForTitle = function () {
 				textHeight = 0;
 			} else {
 				throw(e);
-			}
-		}
+      }
+    }
     return $$.config.title_padding.top + textHeight;
 };
 c3_chart_internal_fn.getTitlePadding = function() {


### PR DESCRIPTION
Firefox has an issue with getting the bounding box for non-attached nodes or attached but hidden nodes. 

See https://bugzilla.mozilla.org/show_bug.cgi?id=612118 for more info. Right now this throws an exception and breaks the chart generation.

I am re-throwing other exceptions except this for now but I think I might change it. The whole chart generation shouldn't break because of the title :)

@masayuki0812 
