### PR TITLE
Fixes Uncaught TypeError: Cannot read property 'gauge_min' of null #1205

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -26,27 +26,29 @@ c3_chart_internal_fn.updateArc = function () {
 
 c3_chart_internal_fn.updateAngle = function (d) {
     var $$ = this, config = $$.config,
-        found = false, index = 0,
-        gMin = config.gauge_min, gMax = config.gauge_max, gTic, gValue;
-    $$.pie($$.filterTargetsToShow($$.data.targets)).forEach(function (t) {
-        if (! found && t.data.id === d.data.id) {
-            found = true;
-            d = t;
-            d.index = index;
+        found = false, index = 0;
+    if (config) {  
+        var gMin = config.gauge_min, gMax = config.gauge_max, gTic, gValue;
+        $$.pie($$.filterTargetsToShow($$.data.targets)).forEach(function (t) {
+            if (! found && t.data.id === d.data.id) {
+                found = true;
+                d = t;
+                d.index = index;
+            }
+            index++;
+        });
+        if (isNaN(d.startAngle)) {
+            d.startAngle = 0;
         }
-        index++;
-    });
-    if (isNaN(d.startAngle)) {
-        d.startAngle = 0;
-    }
-    if (isNaN(d.endAngle)) {
-        d.endAngle = d.startAngle;
-    }
-    if ($$.isGaugeType(d.data)) {
-        gTic = (Math.PI) / (gMax - gMin);
-        gValue = d.value < gMin ? 0 : d.value < gMax ? d.value - gMin : (gMax - gMin);
-        d.startAngle = -1 * (Math.PI / 2);
-        d.endAngle = d.startAngle + gTic * gValue;
+        if (isNaN(d.endAngle)) {
+            d.endAngle = d.startAngle;
+        }
+        if ($$.isGaugeType(d.data)) {
+            gTic = (Math.PI) / (gMax - gMin);
+            gValue = d.value < gMin ? 0 : d.value < gMax ? d.value - gMin : (gMax - gMin);
+            d.startAngle = -1 * (Math.PI / 2);
+            d.endAngle = d.startAngle + gTic * gValue;
+        }
     }
     return found ? d : null;
 };


### PR DESCRIPTION
Fix for issue #1205.

I added a console.log while debugging this to verify that this null condition was being hit and that the charts still generated correctly after hitting this. Duplicating this is very timing dependent.