### PR TITLE
grunt-sass version changed to ^1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-sass": "^0.17.0",
+    "grunt-sass": "^1.0.0",
     "load-grunt-tasks": "~0.2.0"
   }
 }


### PR DESCRIPTION
It fix "npm install" fails on node ^0.12 (#1322).