### PR TITLE
Upgrade d3 to 3.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "gitHead": "84e03109d9a590f9c8ef687c03d751f666080c6f",
   "readmeFilename": "README.md",
   "dependencies": {
-    "d3": "<=3.5.0"
+    "d3": "^3.5.4"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
@masayuki0812 I believe d3 can be upgraded to 3.5.4, as https://github.com/mbostock/d3/issues/2174 has been closed.