### PR TITLE
More accurate positioning of y axis tick texts for larger font sizes

### DIFF
--- a/src/c3.axis.js
+++ b/src/c3.axis.js
@@ -151,7 +151,7 @@ function c3_axis(d3, params) {
                 var dy = sizeFor1Char.h;
                 if (i === 0) {
                     if (orient === 'left' || orient === 'right') {
-                        dy = -((counts[d.index] - 1) * (sizeFor1Char.h / 2) - 3);
+                        dy = -((counts[d.index] - 1) * (sizeFor1Char.h / 2) - sizeFor1Char.h / 4);
                     } else {
                         dy = ".71em";
                     }

--- a/src/c3.axis.js
+++ b/src/c3.axis.js
@@ -49,7 +49,7 @@ function c3_axis(d3, params) {
     }
     function textFormatted(v) {
         var formatted = tickFormat ? tickFormat(v) : v;
-        return typeof formatted !== 'undefined' ? formatted : '';
+        return typeof formatted !== 'undefined' ? formatted.toString() : '';
     }
     function getSizeFor1Char(tick) {
         if (tickTextCharSize) {


### PR DESCRIPTION
While using c3js in a project where people demanded larger font sizes for axis ticks, I noticed that changing the font size to 12pt is causing the y axis tick texts to be vertically out of position relative to the actual ticks. The tick texts are not vertically centred at the ticks any more. Here is an example for 12pt:
![12pt_ugly_](https://cloud.githubusercontent.com/assets/5701903/10112516/2f05baf8-63dc-11e5-9fed-5db600c43683.png)
This problem becomes more obvious if you increase the font size. Here an example for 20pt:
![20pt_ugly](https://cloud.githubusercontent.com/assets/5701903/10112571/7f5f1292-63dc-11e5-9268-84478759b608.png)
The changes applied by me lead to the following results for 12pt and 20pt:
![12pt](https://cloud.githubusercontent.com/assets/5701903/10112603/c86ccce0-63dc-11e5-8661-3267fc8bb295.png)
![20pt](https://cloud.githubusercontent.com/assets/5701903/10112604/cdd4908c-63dc-11e5-8b02-9a162eb227c9.png)
Also tried other font sizes from 6pt to 30pt and the results are still accurate.
I've found the reason for this problem in the methods tspanDy(d, i) and textFormatted(d). In tspanDy(d, i), a fixed value (3) has been used to centre the tick text vertically, but using a quarter of the height of a char to compute the vertical offset of tick texts results in a more accurate positioning. The method textFormatted(d) is used to detect the height of the chars in the tick texts. But it fails if the tick "text" is a number. To solve this issue I ensured that textFormatted(d) will return a string in any case.

Do you think these changes are ok?