### PR TITLE
Add test coverage reporting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ d3.min.js
 components
 build
 .sass-cache
+
+# coverage report
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ language: node_js
 before_script:
 - npm install -g grunt-cli
 - gem install sass
+
+script:
+- npm run lint
+- npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ before_script:
 script:
 - npm run lint
 - npm test
+
+after_success:
+- npm run codecov

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -85,15 +85,6 @@ module.exports = (grunt) ->
           options:
             jshintrc: '.jshintrc'
 
-        jasmine:
-          c3:
-            src: 'c3.js'
-            options:
-              specs: 'spec/*-spec.js'
-              helpers: 'spec/*-helper.js'
-              styles: 'c3.css'
-              vendor: 'https://rawgit.com/mbostock/d3/v3.5.0/d3.min.js'
-
         uglify:
           c3:
             files:
@@ -111,4 +102,6 @@ module.exports = (grunt) ->
             files:
               'c3.css': 'src/scss/main.scss'
 
-    grunt.registerTask 'default', ['concat', 'jshint', 'jasmine', 'sass', 'cssmin', 'uglify']
+    grunt.registerTask 'lint', ['jshint']
+    grunt.registerTask 'build', ['concat', 'sass', 'cssmin', 'uglify']
+    grunt.registerTask 'defualt', ['lint', 'build']

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,71 @@
+// Karma configuration
+// Generated on Wed Sep 30 2015 22:01:48 GMT+0900 (KST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'node_modules/d3/d3.min.js',
+      'c3.js',
+      'c3.css',
+      'spec/*-helper.js',
+      'spec/*-spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['spec'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_DEBUG,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    browserNoActivityTimeout: 60000,
+  })
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,13 +31,19 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      'c3.js': ['coverage']
     },
 
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['spec'],
+    reporters: ['spec', 'coverage'],
+
+
+    coverageReporter: {
+      reporters: [{type: 'lcov'}]
+    },
 
 
     // web server port
@@ -50,7 +56,7 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_DEBUG,
+    logLevel: config.LOG_INFO,
 
 
     // enable / disable watching file and executing tests whenever any file changes

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "c3.js",
   "scripts": {
     "lint": "grunt lint",
-    "test": "karma start karma.conf.js"
+    "test": "karma start karma.conf.js",
+    "codecov": "cat coverage/*/lcov.info | codecov"
   },
   "repository": {
     "type": "git",
@@ -24,6 +25,7 @@
     "d3": "<=3.5.0"
   },
   "devDependencies": {
+    "codecov.io": "^0.1.6",
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-cssmin": "^0.10.0",
@@ -33,8 +35,10 @@
     "grunt-sass": "^0.17.0",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.10",
+    "karma-coverage": "^0.5.2",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
+    "karma-spec-reporter": "0.0.20",
     "load-grunt-tasks": "~0.2.0",
     "phantomjs": "^1.9.18"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "D3-based reusable chart library",
   "main": "c3.js",
   "scripts": {
-    "test": "grunt"
+    "lint": "grunt lint",
+    "test": "karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -26,11 +27,15 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-cssmin": "^0.10.0",
-    "grunt-contrib-jasmine": "~0.8.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-sass": "^0.17.0",
-    "load-grunt-tasks": "~0.2.0"
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.13.10",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "load-grunt-tasks": "~0.2.0",
+    "phantomjs": "^1.9.18"
   }
 }


### PR DESCRIPTION
Hi, @masayuki0812 

This change adds coverage report and uploads it to [codecov.io](https://codecov.io). This creates coverage report available online like [this](https://codecov.io/github/kt3k/c3/c3.js?ref=4ed3742e444ef501a8d257f1cbd31e930bf4665a). It says the current line coverage is 72.45%.

In order to achieve the above, I switched test framework from `grunt-contrib-jasmine` to [karma](http://karma-runner.github.io/0.13/index.html). `karma` has lots of advantages over `grunt-contrib-jasmine` IMO.
- karma can run lots of browsers other than PhantomJS.
- karma has good coverage support
- The plugin ecosystem seems very well and rich. There are lots of useful tools like karma-browserify, karma-sinon etc.

By the way `testem` is a similar tool as karma but the coverage support seems quite poorer and I don't know how to do it with testem.