### PR TITLE
re #1392 #1399 Update package.json to use D3 v3.5.6 for Windows issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "gitHead": "84e03109d9a590f9c8ef687c03d751f666080c6f",
   "readmeFilename": "README.md",
   "dependencies": {
-    "d3": "<=3.5.0"
+    "d3": "3.5.6"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
This PR fixes an issue for Windows users that want to use C3. C3 depends on D3, which depends on JSDOM, which depends on Contextify, which uses node-gyp, which causes issues on Windows due to a lack of a C/C++ compiler, the need to install Python, etc. D3 has made JSDOM an optional dependency in its most recent version, though C3 is still automatically installing D3 v3.5.0. So, any user on Windows that is using C3 will run into these issues unless the version is changed in the `package.json`.

Ref: https://github.com/mbostock/d3/issues/1986