### PR TITLE
change d3 version, so that npm install doesn't install contextify

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "gitHead": "84e03109d9a590f9c8ef687c03d751f666080c6f",
   "readmeFilename": "README.md",
   "dependencies": {
-    "d3": "~3.5.0"
+    "d3": "3.5.6"
   },
   "devDependencies": {
     "codecov.io": "^0.1.6",


### PR DESCRIPTION
Contextify, a dependency of jsdom, which in turn has been a dependency of d3 in version 3.5, still gets installed when I go `npm install c3@latest`. 

This breaks c3 if you install it via node4 (because building contextify in node 4 isn't possible right now)

Upgrading to the latest minor version of d3 fixes this, because jsdom has been made a dev dependency rather than a hard dependency.