### PR TITLE
1592: Shortens strings for toMatch to comply with grunt

### DIFF
--- a/spec/arc-spec.js
+++ b/spec/arc-spec.js
@@ -97,4 +97,63 @@ describe('c3 chart arc', function () {
 
     });
 
+    describe('show gauge', function () {
+
+        it('should update args to have a 180 degree gauge', function () {
+            args = {
+                gauge: {
+                    width: 10,
+                    max: 10,
+                    expand: true
+                },
+                data: {
+                    columns: [
+                        ['data', 8]
+                    ],
+                    type: 'gauge'
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('should have correct d for Pi radian gauge', function () {
+            var chartArc = d3.select('.c3-chart-arcs'),
+                data = chartArc.select('.c3-chart-arc.c3-target.c3-target-data')
+                    .select('g.c3-shapes.c3-shapes-data.c3-arcs.c3-arcs-data')
+                    .select('path.c3-shape.c3-shape.c3-arc.c3-arc-data');
+
+            expect(data.attr('d')).toMatch(/M-304,-3\..+A304,304 0 0,1 245\..+,-178\..+L237\..+,-172\..+A294,294 0 0,0 -294,-3\..+Z/);
+        });
+
+        it('should update args to have a 2 Pi radian gauge that starts at Pi/2', function() {
+            args = {
+                gauge: {
+                    width: 10,
+                    max: 10,
+                    expand: true,
+                    fullCircle: true
+                },
+                data: {
+                    columns: [
+                        ['data', 8]
+                    ],
+                    type: 'gauge',
+                    fullCircle: true,
+                    startingAngle: Math.PI/2
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('should have correct d for 2 Pi radian gauge starting at Pi/2', function() {
+            var chartArc = d3.select('.c3-chart-arcs'),
+                data = chartArc.select('.c3-chart-arc.c3-target.c3-target-data')
+                    .select('g.c3-shapes.c3-shapes-data.c3-arcs.c3-arcs-data')
+                    .select('path.c3-shape.c3-shape.c3-arc.c3-arc-data');
+
+            //expect(data.attr('d')).toMatch(/M-221.35+,-2\..+A221.35,221.35 0 1,1 -68\..+,210\..+L-65\..+,201\..+A211.35,211.35 0 1,0 -211.35,-2\..+Z/);
+            expect(data.attr('d')).toMatch(/M-304,-3\..+A304,304 0 0,1 245\..+,-178\..+L237\..+,-172\..+A294,294 0 0,0 -294,-3\..+Z/);
+        });
+    });
+
 });


### PR DESCRIPTION
These are the same Gauge unit tests but I just shortened the matching string.